### PR TITLE
Fixed prototype pollution in @fav/prop.assign-deep

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,9 @@ function assignDeep(dest /* , ...src */) {
 
 function assignDeepEach(dest, src) {
   var props = enumOwnProps(src);
+  if(props.includes('__proto__') || props.includes('constructor') || props.includes('prototype')){
+    return false;
+  }
   for (var i = 0, n = props.length; i < n; i++) {
     var prop = props[i];
     var srcValue = src[prop];


### PR DESCRIPTION
### 📊 Metadata *

Prototype pollution in `@fav/prop.assign-deep`

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-%40fav%2Fprop.assign-deep/

### ⚙️ Description *

`@fav/prop.assign-deep` is vulnerable to Prototype Pollution. This package allowing for modification of prototype behavior, which may result in Information Disclosure/DoS/RCE.

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.

### 💻 Technical Description *

The bug is fixed by validating the input `props` to check for prototypes. It is implemented by a simple validation to check for prototype keywords `(__proto__, constructor and prototype)`, where if it exists, the function returns the object without modifying it, thus fixing the Prototype Pollution Vulnerability. 

### 🐛 Proof of Concept (PoC) *

Clone the project, install the required dependencies and on running the below snippet of code, it triggers prototype pollution and logs `Polluted!`.
```javascript
// poc.js
var assignDeep = require('@fav/prop.assign-deep');

console.log("Before", {}.status)
assignDeep({}, JSON.parse('{ "__proto__" : { "status" : "polluted!" } }'));
console.log("After:", status);
```

![image](https://user-images.githubusercontent.com/16708391/107792599-4d498180-6d7b-11eb-980f-12eae7fc9243.png)


### 🔥 Proof of Fix (PoF) *

After the fix is applied, it returns `undefined` since the polluted referred in the PoC is no more accessible(which is intended). Hence fixing the issue.

![image](https://user-images.githubusercontent.com/16708391/107792717-736f2180-6d7b-11eb-811b-4b3730b99fab.png)


### 👍 User Acceptance Testing (UAT)

Just prevented some keywords as `props` and no breaking changes are introduced. :)
